### PR TITLE
Use native Gradle JUnit Platform support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,6 @@ subprojects {
 
 	apply plugin: 'java'
 	apply plugin: 'eclipse'
-	apply plugin: 'org.junit.platform.gradle.plugin'
 
 	sourceCompatibility = '1.8'
 	targetCompatibility = '1.8'
@@ -25,31 +24,11 @@ subprojects {
 	
 	}
 
-	junitPlatform {
-		
-		filters {
-		
-			engines {
-				// include 'junit-jupiter', 'junit-vintage'
-				// exclude 'custom-engine'
-			}
-			
-			tags {
-				// include 'fast'
-				// exclude 'slow'
-			}
-			// includeClassNamePattern '.*Test'
-			
-		}
-		
-		// enableStandardTestTask true
-		reportsDir file('build/test-results/junit-platform') // this is the default
-		//logManager 'org.apache.logging.log4j.jul.LogManager'
-		//logManager 'org.apache.log4j.LogManager'
+	test {
+		useJUnitPlatform()
 	}
 
 	dependencies {
-
 	   //Testing
 	   testCompile "org.assertj:assertj-core:$assertjVersion"
 	   testCompile "org.junit.jupiter:junit-jupiter-api:$junitVersion"


### PR DESCRIPTION
Remove the deprecated `org.junit.platform.gradle.plugin` usage and use native Gradle support.